### PR TITLE
Use identifiers instead of raw pointers.

### DIFF
--- a/src/atomic_box.rs
+++ b/src/atomic_box.rs
@@ -158,8 +158,9 @@ impl<T> AtomicBox<T> {
     }
 
     /// Stores a box into the atomic box if the value held by the atomic box matches the given current handle.
-    /// The return value is a result indicating whether the new box was written and containing the previous box. On success this value is guaranteed to be equal to current.
-    /// In case of failure, the returned value contains the handle that matches the value in the atomic box, and the given new box.
+    /// The return value is a result indicating whether the new box was written and containing the previous box.
+    /// On success the returned handle is guaranteed to match the current value.
+    /// On failure, the returned value contains the handle that matches the value in the atomic box, and the given new box.
     /// compare_exchange takes two Ordering arguments to describe the memory ordering of this operation. success describes the required ordering for the read-modify-write operation that takes place if the comparison with current succeeds. failure describes the required ordering for the load operation that takes place when the comparison fails. Using Acquire as success ordering makes the store part of this operation Relaxed, and using Release makes the successful load Relaxed. The failure ordering can only be SeqCst, Acquire or Relaxed and must be equivalent to or weaker than the success ordering.
     /// Note: This method is only available on platforms that support atomic operations on pointers.
     pub fn compare_exchange(
@@ -172,6 +173,12 @@ impl<T> AtomicBox<T> {
         self.base.compare_exchange(current, new, success, failure)
     }
 
+    /// Stores a box into the atomic box and moves the value in the new box into the atomic box, if the value held by the atomic box matches the given current handle.
+    /// The return value is a result indicating whether the new box was written.
+    /// On success the returned handle is guaranteed to match the current value.
+    /// On failure, the returned value contains the handle that matches the value in the atomic box and new isn't mutated.
+    /// compare_exchange_mut takes two Ordering arguments to describe the memory ordering of this operation. success describes the required ordering for the read-modify-write operation that takes place if the comparison with current succeeds. failure describes the required ordering for the load operation that takes place when the comparison fails. Using Acquire as success ordering makes the store part of this operation Relaxed, and using Release makes the successful load Relaxed. The failure ordering can only be SeqCst, Acquire or Relaxed and must be equivalent to or weaker than the success ordering.
+    /// Note: This method is only available on platforms that support atomic operations on pointers.
     pub fn compare_exchange_mut(
         &self,
         current: Handle<T>,
@@ -183,6 +190,13 @@ impl<T> AtomicBox<T> {
             .compare_exchange_mut(current, new, success, failure)
     }
 
+    /// Stores a box into the atomic box if the value held by the atomic box matches the given current handle.
+    /// Unlike AtomicBox::compare_exchange, this function is allowed to spuriously fail even when the comparison succeeds, which can result in more efficient code on some platforms.
+    /// The return value is a result indicating whether the new box was written and containing the previous box.
+    /// On success the returned handle is guaranteed to match the current value.
+    /// On failure, the returned value contains the handle that matches the value in the atomic box, and the given new box.
+    /// compare_exchange_weak takes two Ordering arguments to describe the memory ordering of this operation. success describes the required ordering for the read-modify-write operation that takes place if the comparison with current succeeds. failure describes the required ordering for the load operation that takes place when the comparison fails. Using Acquire as success ordering makes the store part of this operation Relaxed, and using Release makes the successful load Relaxed. The failure ordering can only be SeqCst, Acquire or Relaxed and must be equivalent to or weaker than the success ordering.
+    /// Note: This method is only available on platforms that support atomic operations on pointers.
     pub fn compare_exchange_weak(
         &self,
         current: Handle<T>,
@@ -194,6 +208,13 @@ impl<T> AtomicBox<T> {
             .compare_exchange_weak(current, new, success, failure)
     }
 
+    /// Stores a box into the atomic box and moves the value in the new box into the atomic box, if the value held by the atomic box matches the given current handle.
+    /// Unlike AtomicBox::compare_exchange_mut, this function is allowed to spuriously fail even when the comparison succeeds, which can result in more efficient code on some platforms.
+    /// The return value is a result indicating whether the new box was written.
+    /// On success the returned handle is guaranteed to match the current value.
+    /// On failure, the returned value contains the handle that matches the value in the atomic box and new isn't mutated.
+    /// compare_exchange_weak_mut takes two Ordering arguments to describe the memory ordering of this operation. success describes the required ordering for the read-modify-write operation that takes place if the comparison with current succeeds. failure describes the required ordering for the load operation that takes place when the comparison fails. Using Acquire as success ordering makes the store part of this operation Relaxed, and using Release makes the successful load Relaxed. The failure ordering can only be SeqCst, Acquire or Relaxed and must be equivalent to or weaker than the success ordering.
+    /// Note: This method is only available on platforms that support atomic operations on pointers.
     pub fn compare_exchange_weak_mut(
         &self,
         current: Handle<T>,

--- a/src/atomic_box.rs
+++ b/src/atomic_box.rs
@@ -214,7 +214,6 @@ impl<T> Debug for AtomicBox<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::atomic::Ordering;
     use std::sync::{Arc, Barrier};
     use std::thread::spawn;
 
@@ -375,8 +374,7 @@ mod tests {
 
     #[test]
     fn atomic_box_drops() {
-        use std::sync::atomic::{AtomicUsize, Ordering};
-        use std::sync::Arc;
+        use std::sync::atomic::AtomicUsize;
 
         struct K(Arc<AtomicUsize>, usize);
 

--- a/src/atomic_box.rs
+++ b/src/atomic_box.rs
@@ -151,10 +151,17 @@ impl<T> AtomicBox<T> {
         unsafe { &mut *(ptr as *mut T) }
     }
 
+    /// Returns a handle that matches the current held box.
+    /// load takes an Ordering argument which describes the memory ordering of this operation. Possible values are SeqCst, Acquire and Relaxed.
     pub fn load_handle(&self, order: Ordering) -> Handle<T> {
         self.base.load_handle(order)
     }
 
+    /// Stores a box into the atomic box if the value held by the atomic box matches the given current handle.
+    /// The return value is a result indicating whether the new box was written and containing the previous box. On success this value is guaranteed to be equal to current.
+    /// In case of failure, the returned value contains the handle that matches the value in the atomic box, and the given new box.
+    /// compare_exchange takes two Ordering arguments to describe the memory ordering of this operation. success describes the required ordering for the read-modify-write operation that takes place if the comparison with current succeeds. failure describes the required ordering for the load operation that takes place when the comparison fails. Using Acquire as success ordering makes the store part of this operation Relaxed, and using Release makes the successful load Relaxed. The failure ordering can only be SeqCst, Acquire or Relaxed and must be equivalent to or weaker than the success ordering.
+    /// Note: This method is only available on platforms that support atomic operations on pointers.
     pub fn compare_exchange(
         &self,
         current: Handle<T>,

--- a/src/atomic_box.rs
+++ b/src/atomic_box.rs
@@ -157,6 +157,13 @@ impl<T> AtomicBox<T> {
         self.base.load_handle(order)
     }
 
+    /// Returns a pointer to the currently held box. Using the pointer is unsafe for all of the usual reasons; e.g., the box might have been dropped from
+    /// the atomic by another thread by the time the pointer is dereferenced.
+    /// load takes an Ordering argument which describes the memory ordering of this operation. Possible values are SeqCst, Acquire and Relaxed.
+    pub fn load_pointer(&self, order: Ordering) -> *mut T {
+        self.base.load_pointer(order)
+    }
+
     /// Stores a box into the atomic if the value held by the atomic matches the given current handle.
     /// The return value is a result indicating whether the new box was written and containing the previous box.
     /// On success the returned handle is guaranteed to match the current value.

--- a/src/atomic_box.rs
+++ b/src/atomic_box.rs
@@ -157,10 +157,10 @@ impl<T> AtomicBox<T> {
         self.base.load_handle(order)
     }
 
-    /// Stores a box into the atomic box if the value held by the atomic box matches the given current handle.
+    /// Stores a box into the atomic if the value held by the atomic matches the given current handle.
     /// The return value is a result indicating whether the new box was written and containing the previous box.
     /// On success the returned handle is guaranteed to match the current value.
-    /// On failure, the returned value contains the handle that matches the value in the atomic box, and the given new box.
+    /// On failure, the returned value contains the handle that matches the value in the atomic, and the given new box.
     /// compare_exchange takes two Ordering arguments to describe the memory ordering of this operation. success describes the required ordering for the read-modify-write operation that takes place if the comparison with current succeeds. failure describes the required ordering for the load operation that takes place when the comparison fails. Using Acquire as success ordering makes the store part of this operation Relaxed, and using Release makes the successful load Relaxed. The failure ordering can only be SeqCst, Acquire or Relaxed and must be equivalent to or weaker than the success ordering.
     /// Note: This method is only available on platforms that support atomic operations on pointers.
     pub fn compare_exchange(
@@ -173,10 +173,10 @@ impl<T> AtomicBox<T> {
         self.base.compare_exchange(current, new, success, failure)
     }
 
-    /// Stores a box into the atomic box and moves the value in the new box into the atomic box, if the value held by the atomic box matches the given current handle.
+    /// Stores the new box into the atomic and moves the value in the atomic into the new box, if the value held by the atomic matches the given current handle.
     /// The return value is a result indicating whether the new box was written.
     /// On success the returned handle is guaranteed to match the current value.
-    /// On failure, the returned value contains the handle that matches the value in the atomic box and new isn't mutated.
+    /// On failure, the returned value contains the handle that matches the value in the atomic, and new isn't mutated.
     /// compare_exchange_mut takes two Ordering arguments to describe the memory ordering of this operation. success describes the required ordering for the read-modify-write operation that takes place if the comparison with current succeeds. failure describes the required ordering for the load operation that takes place when the comparison fails. Using Acquire as success ordering makes the store part of this operation Relaxed, and using Release makes the successful load Relaxed. The failure ordering can only be SeqCst, Acquire or Relaxed and must be equivalent to or weaker than the success ordering.
     /// Note: This method is only available on platforms that support atomic operations on pointers.
     pub fn compare_exchange_mut(
@@ -190,11 +190,11 @@ impl<T> AtomicBox<T> {
             .compare_exchange_mut(current, new, success, failure)
     }
 
-    /// Stores a box into the atomic box if the value held by the atomic box matches the given current handle.
+    /// Stores a box into the atomic if the value held by the atomic matches the given current handle.
     /// Unlike AtomicBox::compare_exchange, this function is allowed to spuriously fail even when the comparison succeeds, which can result in more efficient code on some platforms.
     /// The return value is a result indicating whether the new box was written and containing the previous box.
     /// On success the returned handle is guaranteed to match the current value.
-    /// On failure, the returned value contains the handle that matches the value in the atomic box, and the given new box.
+    /// On failure, the returned value contains the handle that matches the value in the atomic, and the given new box unmutated.
     /// compare_exchange_weak takes two Ordering arguments to describe the memory ordering of this operation. success describes the required ordering for the read-modify-write operation that takes place if the comparison with current succeeds. failure describes the required ordering for the load operation that takes place when the comparison fails. Using Acquire as success ordering makes the store part of this operation Relaxed, and using Release makes the successful load Relaxed. The failure ordering can only be SeqCst, Acquire or Relaxed and must be equivalent to or weaker than the success ordering.
     /// Note: This method is only available on platforms that support atomic operations on pointers.
     pub fn compare_exchange_weak(
@@ -208,11 +208,11 @@ impl<T> AtomicBox<T> {
             .compare_exchange_weak(current, new, success, failure)
     }
 
-    /// Stores a box into the atomic box and moves the value in the new box into the atomic box, if the value held by the atomic box matches the given current handle.
+    /// Moves the value in the new box into the atomic and move the value in the atomic into the new box, if the value held by the atomic matches the given current handle.
     /// Unlike AtomicBox::compare_exchange_mut, this function is allowed to spuriously fail even when the comparison succeeds, which can result in more efficient code on some platforms.
     /// The return value is a result indicating whether the new box was written.
     /// On success the returned handle is guaranteed to match the current value.
-    /// On failure, the returned value contains the handle that matches the value in the atomic box and new isn't mutated.
+    /// On failure, the returned value contains the handle that matches the value in the atomic, and new isn't mutated.
     /// compare_exchange_weak_mut takes two Ordering arguments to describe the memory ordering of this operation. success describes the required ordering for the read-modify-write operation that takes place if the comparison with current succeeds. failure describes the required ordering for the load operation that takes place when the comparison fails. Using Acquire as success ordering makes the store part of this operation Relaxed, and using Release makes the successful load Relaxed. The failure ordering can only be SeqCst, Acquire or Relaxed and must be equivalent to or weaker than the success ordering.
     /// Note: This method is only available on platforms that support atomic operations on pointers.
     pub fn compare_exchange_weak_mut(

--- a/src/atomic_box_base.rs
+++ b/src/atomic_box_base.rs
@@ -1,0 +1,160 @@
+use std::mem::forget;
+use std::ptr::{self, null_mut};
+use std::sync::atomic::{AtomicPtr, Ordering};
+
+pub trait PointerConvertible {
+    type Target;
+
+    fn into_raw(b: Self) -> *mut Self::Target;
+    unsafe fn from_raw(raw: *mut Self::Target) -> Self;
+}
+
+pub struct AtomicBoxBase<B: PointerConvertible> {
+    ptr: AtomicPtr<B::Target>,
+}
+
+impl<B: PointerConvertible> AtomicBoxBase<B> {
+    pub fn new(value: B) -> AtomicBoxBase<B> {
+        let abox = AtomicBoxBase {
+            ptr: AtomicPtr::new(null_mut()),
+        };
+        let ptr = B::into_raw(value);
+        if ptr != null_mut() {
+            abox.ptr.store(ptr, Ordering::Release);
+        }
+        abox
+    }
+
+    pub fn swap(&self, other: B, order: Ordering) -> B {
+        let mut result = other;
+        self.swap_mut(&mut result, order);
+        result
+    }
+
+    pub fn store(&self, other: B, order: Ordering) {
+        let mut result = other;
+        self.swap_mut(&mut result, order);
+        drop(result)
+    }
+
+    pub fn swap_mut(&self, other: &mut B, order: Ordering) {
+        match order {
+            Ordering::AcqRel | Ordering::SeqCst => {}
+            _ => panic!("invalid ordering for atomic swap"),
+        }
+
+        let other_ptr = B::into_raw(unsafe { ptr::read(other) });
+        let ptr = self.ptr.swap(other_ptr, order);
+        unsafe {
+            ptr::write(other, B::from_raw(ptr));
+        }
+    }
+
+    pub fn into_inner(self) -> B {
+        let last_ptr = self.ptr.load(Ordering::Acquire);
+        forget(self);
+        unsafe { B::from_raw(last_ptr) }
+    }
+
+    pub fn load_raw(&self, order: Ordering) -> *const B::Target {
+        self.ptr.load(order)
+    }
+
+    pub fn compare_exchange_raw(
+        &self,
+        current: *const B::Target,
+        new: B,
+        success: Ordering,
+        failure: Ordering,
+    ) -> Result<B, (*const B::Target, B)> {
+        let mut local_new = new;
+        let result = self.compare_exchange_raw_mut(current, &mut local_new, success, failure);
+
+        match result {
+            Ok(_) => Ok(local_new),
+            Err(previous_ptr) => Err((previous_ptr, local_new)),
+        }
+    }
+
+    pub fn compare_exchange_raw_mut(
+        &self,
+        current: *const B::Target,
+        new: &mut B,
+        success: Ordering,
+        failure: Ordering,
+    ) -> Result<*const B::Target, *const B::Target> {
+        let new_ptr = B::into_raw(unsafe { ptr::read(new) });
+        let result =
+            self.ptr
+                .compare_exchange(current as *mut B::Target, new_ptr, success, failure);
+
+        match result {
+            Ok(previous_ptr) => {
+                unsafe {
+                    ptr::write(new, B::from_raw(previous_ptr));
+                }
+                Ok(previous_ptr as *const B::Target)
+            }
+            Err(previous_ptr) => Err(previous_ptr as *const B::Target),
+        }
+    }
+
+    pub fn compare_exchange_weak_raw(
+        &self,
+        current: *const B::Target,
+        new: B,
+        success: Ordering,
+        failure: Ordering,
+    ) -> Result<B, (*const B::Target, B)> {
+        let mut local_new = new;
+        let result = self.compare_exchange_weak_raw_mut(current, &mut local_new, success, failure);
+
+        match result {
+            Ok(_) => Ok(local_new),
+            Err(previous_ptr) => Err((previous_ptr, local_new)),
+        }
+    }
+
+    pub fn compare_exchange_weak_raw_mut(
+        &self,
+        current: *const B::Target,
+        new: &mut B,
+        success: Ordering,
+        failure: Ordering,
+    ) -> Result<*const B::Target, *const B::Target> {
+        let new_ptr = B::into_raw(unsafe { ptr::read(new) });
+        let result =
+            self.ptr
+                .compare_exchange_weak(current as *mut B::Target, new_ptr, success, failure);
+
+        match result {
+            Ok(previous_ptr) => {
+                unsafe {
+                    ptr::write(new, B::from_raw(previous_ptr));
+                }
+                Ok(previous_ptr as *const B::Target)
+            }
+            Err(previous_ptr) => Err(previous_ptr as *const B::Target),
+        }
+    }
+}
+
+impl<B: PointerConvertible> Default for AtomicBoxBase<B>
+where
+    B: Default,
+{
+    /// The default `AtomicBox<T>` value boxes the default `T` value.
+    fn default() -> AtomicBoxBase<B> {
+        AtomicBoxBase::new(Default::default())
+    }
+}
+
+impl<B: PointerConvertible> Drop for AtomicBoxBase<B> {
+    /// Dropping an `AtomicBoxBase<T>` drops the final value stored in it.
+    fn drop(&mut self) {
+        let ptr = self.ptr.load(Ordering::Acquire);
+        unsafe {
+            B::from_raw(ptr);
+        }
+    }
+}

--- a/src/atomic_box_base.rs
+++ b/src/atomic_box_base.rs
@@ -82,8 +82,12 @@ impl<B: PointerConvertible> AtomicBoxBase<B> {
 
     pub fn load_handle(&self, order: Ordering) -> Handle<B::Target> {
         Handle {
-            ptr: self.ptr.load(order),
+            ptr: self.load_pointer(order),
         }
+    }
+
+    pub fn load_pointer(&self, order: Ordering) -> *mut B::Target {
+        self.ptr.load(order)
     }
 
     pub fn compare_exchange(

--- a/src/atomic_option_box.rs
+++ b/src/atomic_option_box.rs
@@ -196,6 +196,13 @@ impl<T> AtomicOptionBox<T> {
         self.base.load_handle(order)
     }
 
+    /// Returns a pointer to the currently held box. Using the pointer is unsafe for all of the usual reasons; e.g., the box might have been dropped from
+    /// the atomic by another thread by the time the pointer is dereferenced. If the current option is None, the returned pointer will be a null pointer.
+    /// load takes an Ordering argument which describes the memory ordering of this operation. Possible values are SeqCst, Acquire and Relaxed.
+    pub fn load_pointer(&self, order: Ordering) -> *mut T {
+        self.base.load_pointer(order)
+    }
+
     /// Stores a box into the atomic if the value held by the atomic matches the given current handle.
     /// The return value is a result indicating whether the new box was written and containing the previous box.
     /// On success the returned handle is guaranteed to match the current value.

--- a/src/atomic_option_box.rs
+++ b/src/atomic_option_box.rs
@@ -1,4 +1,4 @@
-use atomic_box_base::{AtomicBoxBase, Handle, PointerConvertible, HandleReferable};
+use atomic_box_base::{AtomicBoxBase, Handle, HandleReferable, PointerConvertible};
 use std::fmt::{self, Debug, Formatter};
 use std::ptr::null_mut;
 use std::sync::atomic::Ordering;
@@ -190,10 +190,18 @@ impl<T> AtomicOptionBox<T> {
         }
     }
 
+    /// Returns a handle that matches the current held option.
+    /// load takes an Ordering argument which describes the memory ordering of this operation. Possible values are SeqCst, Acquire and Relaxed.
     pub fn load_handle(&self, order: Ordering) -> Handle<T> {
         self.base.load_handle(order)
     }
 
+    /// Stores a box into the atomic if the value held by the atomic matches the given current handle.
+    /// The return value is a result indicating whether the new box was written and containing the previous box.
+    /// On success the returned handle is guaranteed to match the current value.
+    /// On failure, the returned value contains the handle that matches the value in the atomic, and the given new box.
+    /// compare_exchange takes two Ordering arguments to describe the memory ordering of this operation. success describes the required ordering for the read-modify-write operation that takes place if the comparison with current succeeds. failure describes the required ordering for the load operation that takes place when the comparison fails. Using Acquire as success ordering makes the store part of this operation Relaxed, and using Release makes the successful load Relaxed. The failure ordering can only be SeqCst, Acquire or Relaxed and must be equivalent to or weaker than the success ordering.
+    /// Note: This method is only available on platforms that support atomic operations on pointers.    
     pub fn compare_exchange(
         &self,
         current: Handle<T>,
@@ -204,6 +212,12 @@ impl<T> AtomicOptionBox<T> {
         self.base.compare_exchange(current, new, success, failure)
     }
 
+    /// Stores an optional box into the atomic and moves the value in the new box into the atomic, if the value held by the atomic matches the given current handle.
+    /// The return value is a result indicating whether the new box was written.
+    /// On success the returned handle is guaranteed to match the current value.
+    /// On failure, the returned value contains the handle that matches the value in the atomic, and new isn't mutated.
+    /// compare_exchange_mut takes two Ordering arguments to describe the memory ordering of this operation. success describes the required ordering for the read-modify-write operation that takes place if the comparison with current succeeds. failure describes the required ordering for the load operation that takes place when the comparison fails. Using Acquire as success ordering makes the store part of this operation Relaxed, and using Release makes the successful load Relaxed. The failure ordering can only be SeqCst, Acquire or Relaxed and must be equivalent to or weaker than the success ordering.
+    /// Note: This method is only available on platforms that support atomic operations on pointers.    
     pub fn compare_exchange_mut(
         &self,
         current: Handle<T>,
@@ -215,6 +229,13 @@ impl<T> AtomicOptionBox<T> {
             .compare_exchange_mut(current, new, success, failure)
     }
 
+    /// Stores an optional box into the atomic if the value held by the atomic matches the given current handle.
+    /// Unlike AtomicBox::compare_exchange, this function is allowed to spuriously fail even when the comparison succeeds, which can result in more efficient code on some platforms.
+    /// The return value is a result indicating whether the new box was written and containing the previous box.
+    /// On success the returned handle is guaranteed to match the current value.
+    /// On failure, the returned value contains the handle that matches the value in the atomic and the given new box.
+    /// compare_exchange_weak takes two Ordering arguments to describe the memory ordering of this operation. success describes the required ordering for the read-modify-write operation that takes place if the comparison with current succeeds. failure describes the required ordering for the load operation that takes place when the comparison fails. Using Acquire as success ordering makes the store part of this operation Relaxed, and using Release makes the successful load Relaxed. The failure ordering can only be SeqCst, Acquire or Relaxed and must be equivalent to or weaker than the success ordering.
+    /// Note: This method is only available on platforms that support atomic operations on pointers.
     pub fn compare_exchange_weak(
         &self,
         current: Handle<T>,
@@ -226,6 +247,13 @@ impl<T> AtomicOptionBox<T> {
             .compare_exchange_weak(current, new, success, failure)
     }
 
+    /// Stores an optional box into the atomic and moves the value in the new box into the atomic, if the value held by the atomic matches the given current handle.
+    /// Unlike AtomicBox::compare_exchange_mut, this function is allowed to spuriously fail even when the comparison succeeds, which can result in more efficient code on some platforms.
+    /// The return value is a result indicating whether the new optional was written.
+    /// On success the returned handle is guaranteed to match the current value.
+    /// On failure, the returned value contains the handle that matches the value in the atomic, and new isn't mutated.
+    /// compare_exchange_weak_mut takes two Ordering arguments to describe the memory ordering of this operation. success describes the required ordering for the read-modify-write operation that takes place if the comparison with current succeeds. failure describes the required ordering for the load operation that takes place when the comparison fails. Using Acquire as success ordering makes the store part of this operation Relaxed, and using Release makes the successful load Relaxed. The failure ordering can only be SeqCst, Acquire or Relaxed and must be equivalent to or weaker than the success ordering.
+    /// Note: This method is only available on platforms that support atomic operations on pointers.
     pub fn compare_exchange_weak_mut(
         &self,
         current: Handle<T>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@
 //! be on the heap.
 
 mod atomic_box;
+mod atomic_box_base;
 mod atomic_option_box;
 
 pub use atomic_box::AtomicBox;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,3 +39,4 @@ mod atomic_option_box;
 
 pub use atomic_box::AtomicBox;
 pub use atomic_option_box::AtomicOptionBox;
+pub use atomic_box_base::Handle;


### PR DESCRIPTION
Instead of returning raw pointers, the atomic box now can return opaque identifiers of its internal state. This will ensure that the users will understand that the comparison results shouldn't be used as pointers, but are merely indicators of the the state of the atomic box.